### PR TITLE
Uhuruhashimoto/neighborinfo 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER mesh
 RUN wget https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -qO /tmp/get-platformio.py && \
 	chmod +x /tmp/get-platformio.py && \
 	python3 /tmp/get-platformio.py && \
-	git clone https://github.com/meshtastic/firmware --recurse-submodules /tmp/firmware && \
+	git clone https://github.com/uhuruhashimoto/firmware.git --recurse-submodules /tmp/firmware && \
 	cd /tmp/firmware && \
 	chmod +x /tmp/firmware/bin/build-native.sh && \
 	source ~/.platformio/penv/bin/activate && \

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -46,6 +46,7 @@ uint32_t NeighborInfoModule::collectNeighborInfo(meshtastic_NeighborInfo *neighb
             neighborInfo->neighbors_count++;
         }
     }
+    printNodeDBSelection("COLLECTED", neighborInfo);
     return neighborInfo->neighbors_count;
 }
 
@@ -57,6 +58,7 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
     meshtastic_MeshPacket *p = allocDataProtobuf(*neighborInfo);
     p->to = dest;
     p->decoded.want_response = wantReplies;
+    printNeighborInfo("SENDING", neighborInfo);
     service.sendToMesh(p);
 }
 

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -1,5 +1,6 @@
 #include "NeighborInfoModule.h"
 #include "NodeDB.h"
+#include "RTC.h"
 
 #define MAX_NEIGHBOR_AGE 10 * 60 * 1000 // 10 minutes
 #define MAX_NUM_NEIGHBORS 10            // also defined in NeighborInfo protobuf options
@@ -15,23 +16,44 @@ NeighborInfoModule::NeighborInfoModule()
 }
 
 /*
-Collect a recieved neighbor info packet from another node
-Pass it to an upper client; do not persist this data on the mesh
+Allocate a zeroed neighbor info packet
 */
-bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_NeighborInfo *np)
+meshtastic_NeighborInfo *NeighborInfoModule::allocateNeighborInfoPacket()
 {
-
-    printNeighborInfo("RECIEVED", np);
+    meshtastic_NeighborInfo *neighborInfo = (meshtastic_NeighborInfo *)malloc(sizeof(meshtastic_NeighborInfo));
+    memset(neighborInfo, 0, sizeof(meshtastic_NeighborInfo));
+    return neighborInfo;
 }
 
-/* Collect neighbor info from the nodeDB's history, capping at a maximum number of entries and max time */
+/*
+Collect neighbor info from the nodeDB's history, capping at a maximum number of entries and max time
+Assumes that the neighborInfo packet has been allocated
+@returns the number of entries collected
+*/
 uint32_t NeighborInfoModule::collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo)
 {
     // TODO: star graph; mask for real neighbors in the nodeDB
+    int num_nodes = nodeDB.getNumNodes();
+    int current_time = getTime();
+
+    for (int i = 0; i < num_nodes; i++) {
+        meshtastic_NodeInfo *dbEntry = nodeDB.getNodeByIndex(i);
+        if ((current_time - dbEntry->last_heard) < MAX_NEIGHBOR_AGE && neighborInfo->neighbors_count < MAX_NUM_NEIGHBORS) {
+            neighborInfo->neighbors[neighborInfo->neighbors_count].node_id = dbEntry->num;
+            neighborInfo->neighbors[neighborInfo->neighbors_count].rx_time = dbEntry->last_heard;
+            neighborInfo->neighbors[neighborInfo->neighbors_count].snr = dbEntry->snr;
+            neighborInfo->neighbors_count++;
+        }
+    }
+    return neighborInfo->neighbors_count;
 }
 
 /* Send neighbor info to the mesh */
-void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies) {}
+void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
+{
+    meshtastic_NeighborInfo *neighborInfo = allocateNeighborInfoPacket();
+    collectNeighborInfo(neighborInfo);
+}
 
 /*
 Encompasses the full construction and sending packet to mesh
@@ -40,22 +62,23 @@ Will be used for broadcast.
 int32_t NeighborInfoModule::runOnce() {}
 
 /*
-Allocate a zeroed neighbor info packet
+Collect a recieved neighbor info packet from another node
+Pass it to an upper client; do not persist this data on the mesh
 */
-meshtastic_NeighborInfo *NeighborInfoModule::allocateNeighborInfoPacket()
+bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_NeighborInfo *np)
 {
-    meshtastic_NeighborInfo *neighborInfo = (meshtastic_NeighborInfo *)malloc(sizeof(meshtastic_NeighborInfo));
-    return neighborInfo;
+    // TODO: check if we want to handle this packet
+    printNeighborInfo("RECIEVED", np);
 }
 
 /*
 Prints a single neighbor info packet and associated neighbors
 NOTE: For debugging only
 */
-void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np);
+void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np) {}
 
 /*
 Prints the nodeDB with selectors for the neighbors we've chosed
 NOTE: For debugging only
 */
-void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np);
+void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np) {}

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -25,7 +25,10 @@ bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Neighbor
 }
 
 /* Collect neighbor info from the nodeDB's history, capping at a maximum number of entries and max time */
-uint32_t NeighborInfoModule::collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo) {}
+uint32_t NeighborInfoModule::collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo)
+{
+    // TODO: star graph; mask for real neighbors in the nodeDB
+}
 
 /* Send neighbor info to the mesh */
 void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies) {}
@@ -37,6 +40,15 @@ Will be used for broadcast.
 int32_t NeighborInfoModule::runOnce() {}
 
 /*
+Allocate a zeroed neighbor info packet
+*/
+meshtastic_NeighborInfo *NeighborInfoModule::allocateNeighborInfoPacket()
+{
+    meshtastic_NeighborInfo *neighborInfo = (meshtastic_NeighborInfo *)malloc(sizeof(meshtastic_NeighborInfo));
+    return neighborInfo;
+}
+
+/*
 Prints a single neighbor info packet and associated neighbors
 NOTE: For debugging only
 */
@@ -46,4 +58,4 @@ void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np);
 Prints the nodeDB with selectors for the neighbors we've chosed
 NOTE: For debugging only
 */
-void printNodeDBSelection(const char *header, const int level);
+void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np);

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -1,0 +1,49 @@
+#include "NeighborInfoModule.h"
+#include "NodeDB.h"
+
+#define MAX_NEIGHBOR_AGE 10 * 60 * 1000 // 10 minutes
+#define MAX_NUM_NEIGHBORS 10            // also defined in NeighborInfo protobuf options
+NeighborInfoModule *neighborInfoModule;
+
+/* Send our initial owner announcement 30 seconds after we start (to give network time to setup) */
+NeighborInfoModule::NeighborInfoModule()
+    : ProtobufModule("neighborinfo", meshtastic_PortNum_PRIVATE_APP, &meshtastic_NeighborInfo_msg), concurrency::OSThread(
+                                                                                                        "NeighborInfoModule")
+{
+    ourPortNum = meshtastic_PortNum_PRIVATE_APP;
+    setIntervalFromNow(30 * 1000);
+}
+
+/*
+Collect a recieved neighbor info packet from another node
+Pass it to an upper client; do not persist this data on the mesh
+*/
+bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_NeighborInfo *np)
+{
+
+    printNeighborInfo("RECIEVED", np);
+}
+
+/* Collect neighbor info from the nodeDB's history, capping at a maximum number of entries and max time */
+uint32_t NeighborInfoModule::collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo) {}
+
+/* Send neighbor info to the mesh */
+void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies) {}
+
+/*
+Encompasses the full construction and sending packet to mesh
+Will be used for broadcast.
+*/
+int32_t NeighborInfoModule::runOnce() {}
+
+/*
+Prints a single neighbor info packet and associated neighbors
+NOTE: For debugging only
+*/
+void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np);
+
+/*
+Prints the nodeDB with selectors for the neighbors we've chosed
+NOTE: For debugging only
+*/
+void printNodeDBSelection(const char *header, const int level);

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -83,12 +83,43 @@ bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Neighbor
 
 /*
 Prints a single neighbor info packet and associated neighbors
+Uses LOG_DEBUG, which equates to Console.log
 NOTE: For debugging only
 */
-void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np) {}
+void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np)
+{
+    LOG_DEBUG("%s NEIGHBORINFO PACKET\n----------------\n", header);
+    LOG_DEBUG("Packet contains %d neighbors\n", np->neighbors_count);
+    for (int i = 0; i < np->neighbors_count; i++) {
+        LOG_DEBUG("Neighbor %d: node_id=%d, rx_time=%d, snr=%d\n", i, np->neighbors[i].node_id, np->neighbors[i].rx_time,
+                  np->neighbors[i].snr);
+    }
+    LOG_DEBUG("----------------\n");
+}
 
 /*
-Prints the nodeDB with selectors for the neighbors we've chosed
+Prints the nodeDB with selectors for the neighbors we've chosen to send (inefficiently)
+Uses LOG_DEBUG, which equates to Console.log
 NOTE: For debugging only
 */
-void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np) {}
+void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np)
+{
+    int num_nodes = nodeDB.getNumNodes();
+    LOG_DEBUG("%s NODEDB SELECTION:\n----------------\n", header);
+    LOG_DEBUG("Selected %d neighbors of %d DB nodes\n", np->neighbors_count, num_nodes);
+    for (int i = 0; i < num_nodes; i++) {
+        meshtastic_NodeInfo *dbEntry = nodeDB.getNodeByIndex(i);
+        bool chosen = false;
+        for (int j = 0; j < np->neighbors_count; j++) {
+            if (np->neighbors[j].node_id == dbEntry->num) {
+                chosen = true;
+            }
+        }
+        if (!chosen) {
+            LOG_DEBUG("     Node %d: node_id=%d, rx_time=%d, snr=%d\n", i, dbEntry->num, dbEntry->last_heard, dbEntry->snr);
+        } else {
+            LOG_DEBUG("---> Node %d: node_id=%d, rx_time=%d, snr=%d\n", i, dbEntry->num, dbEntry->last_heard, dbEntry->snr);
+        }
+    }
+    LOG_DEBUG("----------------\n");
+}

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -7,6 +7,9 @@
 #define MAX_NUM_NEIGHBORS 10            // also defined in NeighborInfo protobuf options
 NeighborInfoModule *neighborInfoModule;
 
+void printNeighborInfo(const char *header, const meshtastic_NeighborInfo *np);
+void printNodeDBSelection(const char *header, const meshtastic_NeighborInfo *np);
+
 /* Send our initial owner announcement 30 seconds after we start (to give network time to setup) */
 NeighborInfoModule::NeighborInfoModule()
     : ProtobufModule("neighborinfo", meshtastic_PortNum_PRIVATE_APP, &meshtastic_NeighborInfo_msg), concurrency::OSThread(
@@ -81,6 +84,8 @@ bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_Neighbor
 {
     // TODO: check if we want to handle this packet
     printNeighborInfo("RECIEVED", np);
+    // No need for others to handle this packet
+    return true;
 }
 
 /*

--- a/src/modules/NeighborInfoModule.cpp
+++ b/src/modules/NeighborInfoModule.cpp
@@ -1,4 +1,5 @@
 #include "NeighborInfoModule.h"
+#include "MeshService.h"
 #include "NodeDB.h"
 #include "RTC.h"
 
@@ -53,13 +54,22 @@ void NeighborInfoModule::sendNeighborInfo(NodeNum dest, bool wantReplies)
 {
     meshtastic_NeighborInfo *neighborInfo = allocateNeighborInfoPacket();
     collectNeighborInfo(neighborInfo);
+    meshtastic_MeshPacket *p = allocDataProtobuf(*neighborInfo);
+    p->to = dest;
+    p->decoded.want_response = wantReplies;
+    service.sendToMesh(p);
 }
 
 /*
 Encompasses the full construction and sending packet to mesh
 Will be used for broadcast.
 */
-int32_t NeighborInfoModule::runOnce() {}
+int32_t NeighborInfoModule::runOnce()
+{
+    bool requestReplies = false;
+    sendNeighborInfo(NODENUM_BROADCAST, requestReplies);
+    return default_broadcast_interval_secs * 1000;
+}
 
 /*
 Collect a recieved neighbor info packet from another node

--- a/src/modules/NeighborInfoModule.h
+++ b/src/modules/NeighborInfoModule.h
@@ -33,7 +33,7 @@ class NeighborInfoModule : public ProtobufModule<meshtastic_NeighborInfo>, priva
     uint32_t collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo);
 
     /* Allocate a new NeighborInfo packet */
-    meshtastic_NeighborInfo *NeighborInfoModule::allocateNeighborInfoPacket();
+    meshtastic_NeighborInfo *allocateNeighborInfoPacket();
 
     /* Does our periodic broadcast */
     virtual int32_t runOnce() override;

--- a/src/modules/NeighborInfoModule.h
+++ b/src/modules/NeighborInfoModule.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "ProtobufModule.h"
+#include "mesh/generated/meshtastic/neighborinfo.pb.h"
+
+/*
+ * Neighborinfo module for sending info on each node's 0-hop neighbors to the mesh
+ * This partners with neighbor bit fields in the NodeInfo packet/NodeDB to allow nodes to declare their status
+ */
+class NeighborInfoModule : public ProtobufModule<meshtastic_NeighborInfo>, private concurrency::OSThread
+{
+  public:
+    /*
+     * Expose the constructor
+     */
+    NeighborInfoModule();
+
+    /*
+     * Send info on our node's neighbors into the mesh
+     */
+    void sendNeighborInfo(NodeNum dest = NODENUM_BROADCAST, bool wantReplies = false);
+
+  protected:
+    /*
+     * Called to handle a particular incoming message
+     * @return true if you've guaranteed you've handled this message and no other handlers should be considered for it
+     */
+    bool handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshtastic_NeighborInfo *nb) override;
+
+    /*
+     * Collect neighbor info from the nodeDB's history, capping at a maximum number of entries and max time
+     * @return the number of entries collected
+     */
+    uint32_t collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo);
+
+    /** Does our periodic broadcast */
+    virtual int32_t runOnce() override;
+};
+extern NeighborInfoModule *neighborInfoModule;

--- a/src/modules/NeighborInfoModule.h
+++ b/src/modules/NeighborInfoModule.h
@@ -32,7 +32,10 @@ class NeighborInfoModule : public ProtobufModule<meshtastic_NeighborInfo>, priva
      */
     uint32_t collectNeighborInfo(meshtastic_NeighborInfo *neighborInfo);
 
-    /** Does our periodic broadcast */
+    /* Allocate a new NeighborInfo packet */
+    meshtastic_NeighborInfo *NeighborInfoModule::allocateNeighborInfoPacket();
+
+    /* Does our periodic broadcast */
     virtual int32_t runOnce() override;
 };
 extern NeighborInfoModule *neighborInfoModule;


### PR DESCRIPTION
## NeighborInfo Constructors and Printing Utilities

This PR sets up constructors and modules for a new NeighborInfo packet (already on main in the forked protobufs module). It also points the Dockerfile to the forked repo so that we can simulate with the new packet. 

Note: This packet is not yet functional in the context of the network. This PR does not contain receive logic (handling the packet), nor does it contain logic to store neighbor status in the database (which currently stores all intercepted packets, not only those of a node's neighbors). 
