### PR TITLE
changing dockerfile back in favor of native sim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER mesh
 RUN wget https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -qO /tmp/get-platformio.py && \
 	chmod +x /tmp/get-platformio.py && \
 	python3 /tmp/get-platformio.py && \
-	git clone https://github.com/uhuruhashimoto/firmware.git --recurse-submodules /tmp/firmware && \
+	git clone https://github.com/meshtastic/firmware --recurse-submodules /tmp/firmware && \
 	cd /tmp/firmware && \
 	chmod +x /tmp/firmware/bin/build-native.sh && \
 	source ~/.platformio/penv/bin/activate && \


### PR DESCRIPTION
## Bye Docker (One Liner)

Removing line in dockerfile (it didn't work anyway) because I don't want to mess with git fetch and git switch to get real time adjustments to the simulation. Instead, I'll just go run it on Linux and build with platformio like a sane person. 
