### PR TITLE
added mask in nodeDB to ensure 2 byte ID, changed port from private a…

### DIFF
--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -94,7 +94,14 @@ class NodeDB
     void updateUser(uint32_t nodeId, const meshtastic_User &p);
 
     /// @return our node number
-    NodeNum getNodeNum() { return myNodeInfo.my_node_num; }
+    NodeNum getNodeNum()
+    {
+        uint32_t num = myNodeInfo.my_node_num;
+        if (num > UINT16_MAX) {
+            num = num & 0x0000ffff;
+        }
+        return num;
+    }
 
     size_t getNumNodes() { return *numNodes; }
 

--- a/src/modules/NodeInfoModule.cpp
+++ b/src/modules/NodeInfoModule.cpp
@@ -71,7 +71,5 @@ int32_t NodeInfoModule::runOnce()
         sendOurNodeInfo(NODENUM_BROADCAST, requestReplies); // Send our info (don't request replies)
     }
 
-    return 30 * 1000; // TODO: REMOVEME heighborinfo testing only
-
-    // return getConfiguredOrDefaultMs(config.device.node_info_broadcast_secs, default_broadcast_interval_secs);
+    return getConfiguredOrDefaultMs(config.device.node_info_broadcast_secs, default_broadcast_interval_secs);
 }


### PR DESCRIPTION
## Goal
Patches and changes to integrate the forked firmware with the backend of our client.

## Implementation
- added mask in nodeDB and `collectNeighborInfo` to ensure 2 byte ID
- changed port from private app (256) to dedicated NeighborInfo port (71)
- Added args to send function in NeighborInfo module so we cc our own packet to our phone (and, by extension, the client)

Note: In this PR, we drop NodeInfo frequency back to the default (15 min), but are still sending NeighborInfos every 30 seconds.

## Testing
Tested in hardware with two nodes on client (https://github.com/ajmcquilkin/meshtastic-emergency-response-client)
